### PR TITLE
Gateway Version move to status

### DIFF
--- a/apis/aviatrix/v1alpha1/zz_gateway_types.go
+++ b/apis/aviatrix/v1alpha1/zz_gateway_types.go
@@ -29,6 +29,10 @@ type GatewayObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
+	// The image version of the gateway. Use aviatrix_gateway_image data source to programmatically retrieve this value for the desired software_version. If set, we will attempt to update the gateway to the specified version if current version is different. If left blank, the gateway upgrades can be managed with the aviatrix_controller_config resource. Type: String. Example: "hvm-cloudx-aws-022021". Available as of provider version R2.20.0.
+	// image_version can be used to set the desired image version of the gateway. If set, we will attempt to update the gateway to the specified version.
+	ImageVersion *string `json:"imageVersion,omitempty" tf:"image_version,omitempty"`
+
 	// Cloud instance ID of the HA gateway.
 	// Instance ID of the peering HA gateway.
 	PeeringHaCloudInstanceID *string `json:"peeringHaCloudInstanceId,omitempty" tf:"peering_ha_cloud_instance_id,omitempty"`
@@ -56,6 +60,10 @@ type GatewayObservation struct {
 	// Security group used for the gateway.
 	// Security group used for the gateway.
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
+
+	// The software version of the gateway. If set, we will attempt to update the gateway to the specified version if current version is different. If left blank, the gateway upgrade can be managed with the aviatrix_controller_config resource. Type: String. Example: "6.5.821". Available as of provider version R2.20.0.
+	// software_version can be used to set the desired software version of the gateway. If set, we will attempt to update the gateway to the specified version. If left blank, the gateway software version will continue to be managed through the aviatrix_controller_config resource.
+	SoftwareVersion *string `json:"softwareVersion,omitempty" tf:"software_version,omitempty"`
 }
 
 type GatewayParameters struct {
@@ -204,11 +212,6 @@ type GatewayParameters struct {
 	// Typed value when modifying idle_timeout. If it's -1, this feature is disabled.
 	// +kubebuilder:validation:Optional
 	IdleTimeout *float64 `json:"idleTimeout,omitempty" tf:"idle_timeout,omitempty"`
-
-	// The image version of the gateway. Use aviatrix_gateway_image data source to programmatically retrieve this value for the desired software_version. If set, we will attempt to update the gateway to the specified version if current version is different. If left blank, the gateway upgrades can be managed with the aviatrix_controller_config resource. Type: String. Example: "hvm-cloudx-aws-022021". Available as of provider version R2.20.0.
-	// image_version can be used to set the desired image version of the gateway. If set, we will attempt to update the gateway to the specified version.
-	// +kubebuilder:validation:Optional
-	ImageVersion *string `json:"imageVersion,omitempty" tf:"image_version,omitempty"`
 
 	// , please see notes here.
 	// Enable Insane Mode for Gateway. Valid values: true, false.
@@ -374,11 +377,6 @@ type GatewayParameters struct {
 	// Enable Source NAT for this container.
 	// +kubebuilder:validation:Optional
 	SingleIPSnat *bool `json:"singleIpSnat,omitempty" tf:"single_ip_snat,omitempty"`
-
-	// The software version of the gateway. If set, we will attempt to update the gateway to the specified version if current version is different. If left blank, the gateway upgrade can be managed with the aviatrix_controller_config resource. Type: String. Example: "6.5.821". Available as of provider version R2.20.0.
-	// software_version can be used to set the desired software version of the gateway. If set, we will attempt to update the gateway to the specified version. If left blank, the gateway software version will continue to be managed through the aviatrix_controller_config resource.
-	// +kubebuilder:validation:Optional
-	SoftwareVersion *string `json:"softwareVersion,omitempty" tf:"software_version,omitempty"`
 
 	// Enable/disable Split Tunnel Mode. Valid values: true, false. Default value: true. Please see here for more information on split tunnel.
 	// Specify split tunnel mode.

--- a/apis/aviatrix/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/aviatrix/v1alpha1/zz_generated.deepcopy.go
@@ -565,6 +565,11 @@ func (in *GatewayObservation) DeepCopyInto(out *GatewayObservation) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ImageVersion != nil {
+		in, out := &in.ImageVersion, &out.ImageVersion
+		*out = new(string)
+		**out = **in
+	}
 	if in.PeeringHaCloudInstanceID != nil {
 		in, out := &in.PeeringHaCloudInstanceID, &out.PeeringHaCloudInstanceID
 		*out = new(string)
@@ -597,6 +602,11 @@ func (in *GatewayObservation) DeepCopyInto(out *GatewayObservation) {
 	}
 	if in.SecurityGroupID != nil {
 		in, out := &in.SecurityGroupID, &out.SecurityGroupID
+		*out = new(string)
+		**out = **in
+	}
+	if in.SoftwareVersion != nil {
+		in, out := &in.SoftwareVersion, &out.SoftwareVersion
 		*out = new(string)
 		**out = **in
 	}
@@ -758,11 +768,6 @@ func (in *GatewayParameters) DeepCopyInto(out *GatewayParameters) {
 	if in.IdleTimeout != nil {
 		in, out := &in.IdleTimeout, &out.IdleTimeout
 		*out = new(float64)
-		**out = **in
-	}
-	if in.ImageVersion != nil {
-		in, out := &in.ImageVersion, &out.ImageVersion
-		*out = new(string)
 		**out = **in
 	}
 	if in.InsaneMode != nil {
@@ -946,11 +951,6 @@ func (in *GatewayParameters) DeepCopyInto(out *GatewayParameters) {
 	if in.SingleIPSnat != nil {
 		in, out := &in.SingleIPSnat, &out.SingleIPSnat
 		*out = new(bool)
-		**out = **in
-	}
-	if in.SoftwareVersion != nil {
-		in, out := &in.SoftwareVersion, &out.SoftwareVersion
-		*out = new(string)
 		**out = **in
 	}
 	if in.SplitTunnel != nil {

--- a/config/null/config.go
+++ b/config/null/config.go
@@ -5,13 +5,18 @@ Copyright 2021 Upbound Inc.
 package null
 
 import (
+	"github.com/upbound/upjet/pkg/config"
 	ujconfig "github.com/upbound/upjet/pkg/config"
 )
 
 // Configure configures the null group
 func Configure(p *ujconfig.Provider) {
-	p.AddResourceConfigurator("null_resource", func(r *ujconfig.Resource) {
-		r.Kind = "Resource"
-		// And other overrides.
+	p.AddResourceConfigurator("aviatrix_gateway", func(r *config.Resource) {
+		// r.LateInitializer = config.LateInitializer{
+		// 	IgnoredFields: []string{"software_version"},
+
+		// }
+		config.MoveToStatus(r.TerraformResource, "software_version")
+		config.MoveToStatus(r.TerraformResource, "image_version")
 	})
 }

--- a/examples/gateway.yaml
+++ b/examples/gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: aviatrix.aviatrix.upbound.io/v1alpha1
+kind: Gateway
+metadata:
+  annotations:
+    meta.upbound.io/example-id: aviatrix/v1alpha1/gateway
+  labels:
+    testing.upbound.io/example-name: test_gateway_aws
+  name: test-gateway-aws
+spec:
+  forProvider:
+    accountName: aviatrix
+    cloudType: 4
+    idleTimeout: 301
+    renegotiationInterval: 301
+    gwSize: n1-highcpu-16
+    vpcId: gcloud-vpc~-~mconnors-01
+    subnet: 10.10.0.0/24
+    vpcReg: us-west1-a
+
+---
+

--- a/examples/vpc.yaml
+++ b/examples/vpc.yaml
@@ -1,0 +1,56 @@
+apiVersion: aviatrix.aviatrix.upbound.io/v1alpha1
+kind: VPC
+metadata:
+  annotations:
+    crossplane.io/external-create-pending: "2023-06-05T21:56:22Z"
+    crossplane.io/external-create-succeeded: "2023-06-05T21:56:22Z"
+    crossplane.io/external-name: gcloud-vpc
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"aviatrix.aviatrix.upbound.io/v1alpha1","kind":"VPC","metadata":{"annotations":{"meta.upbound.io/example-id":"aviatrix/v1alpha1/vpc"},"labels":{"testing.upbound.io/example-name":"gcloud_vpc"},"name":"gcloud-vpc"},"spec":{"forProvider":{"accountName":"aviatrix","aviatrixFirenetVpc":false,"aviatrixTransitVpc":false,"cloudType":4,"subnets":[{"cidr":"10.10.0.0/24","name":"subnet-1","region":"us-west1"}]}}}
+    meta.upbound.io/example-id: aviatrix/v1alpha1/vpc
+    upjet.crossplane.io/provider-meta: '{"schema_version":"1"}'
+  creationTimestamp: "2023-06-05T21:19:10Z"
+  finalizers:
+  - finalizer.managedresource.crossplane.io
+  generation: 3
+  labels:
+    testing.upbound.io/example-name: gcloud_vpc
+  name: gcloud-vpc
+  resourceVersion: "71149105"
+  uid: 5769a2ef-daf0-4a7d-bfd2-efca4fcb6887
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    accountName: aviatrix
+    aviatrixFirenetVpc: false
+    aviatrixTransitVpc: false
+    cloudType: 4
+    subnets:
+    - cidr: 10.10.0.0/24
+      name: subnet-1
+      region: us-west1
+  providerConfigRef:
+    name: default
+status:
+  atProvider:
+    id: gcloud-vpc
+    subnets:
+    - subnetId: ""
+    vpcId: gcloud-vpc~-~mconnors-01
+  conditions:
+  - lastTransitionTime: "2023-06-05T21:57:03Z"
+    reason: Available
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2023-06-05T21:44:27Z"
+    reason: ReconcileSuccess
+    status: "True"
+    type: Synced
+  - lastTransitionTime: "2023-06-05T21:56:57Z"
+    reason: Finished
+    status: "True"
+    type: AsyncOperation
+  - lastTransitionTime: "2023-06-05T21:56:57Z"
+    reason: Success
+    status: "True"
+    type: LastAsyncOperation

--- a/package/crds/aviatrix.aviatrix.upbound.io_gateways.yaml
+++ b/package/crds/aviatrix.aviatrix.upbound.io_gateways.yaml
@@ -258,18 +258,6 @@ spec:
                       R2.17.1+. Typed value when modifying idle_timeout. If it's -1,
                       this feature is disabled.
                     type: number
-                  imageVersion:
-                    description: 'The image version of the gateway. Use aviatrix_gateway_image
-                      data source to programmatically retrieve this value for the
-                      desired software_version. If set, we will attempt to update
-                      the gateway to the specified version if current version is different.
-                      If left blank, the gateway upgrades can be managed with the
-                      aviatrix_controller_config resource. Type: String. Example:
-                      "hvm-cloudx-aws-022021". Available as of provider version R2.20.0.
-                      image_version can be used to set the desired image version of
-                      the gateway. If set, we will attempt to update the gateway to
-                      the specified version.'
-                    type: string
                   insaneMode:
                     description: ', please see notes here. Enable Insane Mode for
                       Gateway. Valid values: true, false.'
@@ -512,18 +500,6 @@ spec:
                       SNAT for FQDN use-case, please see notes Enable Source NAT for
                       this container.'
                     type: boolean
-                  softwareVersion:
-                    description: 'The software version of the gateway. If set, we
-                      will attempt to update the gateway to the specified version
-                      if current version is different. If left blank, the gateway
-                      upgrade can be managed with the aviatrix_controller_config resource.
-                      Type: String. Example: "6.5.821". Available as of provider version
-                      R2.20.0. software_version can be used to set the desired software
-                      version of the gateway. If set, we will attempt to update the
-                      gateway to the specified version. If left blank, the gateway
-                      software version will continue to be managed through the aviatrix_controller_config
-                      resource.'
-                    type: string
                   splitTunnel:
                     description: 'Enable/disable Split Tunnel Mode. Valid values:
                       true, false. Default value: true. Please see here for more information
@@ -800,6 +776,18 @@ spec:
                     type: string
                   id:
                     type: string
+                  imageVersion:
+                    description: 'The image version of the gateway. Use aviatrix_gateway_image
+                      data source to programmatically retrieve this value for the
+                      desired software_version. If set, we will attempt to update
+                      the gateway to the specified version if current version is different.
+                      If left blank, the gateway upgrades can be managed with the
+                      aviatrix_controller_config resource. Type: String. Example:
+                      "hvm-cloudx-aws-022021". Available as of provider version R2.20.0.
+                      image_version can be used to set the desired image version of
+                      the gateway. If set, we will attempt to update the gateway to
+                      the specified version.'
+                    type: string
                   peeringHaCloudInstanceId:
                     description: Cloud instance ID of the HA gateway. Instance ID
                       of the peering HA gateway.
@@ -828,6 +816,18 @@ spec:
                   securityGroupId:
                     description: Security group used for the gateway. Security group
                       used for the gateway.
+                    type: string
+                  softwareVersion:
+                    description: 'The software version of the gateway. If set, we
+                      will attempt to update the gateway to the specified version
+                      if current version is different. If left blank, the gateway
+                      upgrade can be managed with the aviatrix_controller_config resource.
+                      Type: String. Example: "6.5.821". Available as of provider version
+                      R2.20.0. software_version can be used to set the desired software
+                      version of the gateway. If set, we will attempt to update the
+                      gateway to the specified version. If left blank, the gateway
+                      software version will continue to be managed through the aviatrix_controller_config
+                      resource.'
                     type: string
                 type: object
               conditions:


### PR DESCRIPTION
Prevent gateway version from being auto-populated by moving it to the status field.